### PR TITLE
Add provider debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ const result = await agent.run(messages, tools, providerGroup, {
 console.log(`Plan strategy: ${result.debug.plan.strategy}`);
 console.log(`Steps executed: ${result.debug.steps}`);
 console.log(`Reflections: ${result.debug.reflections}`);
+// See which provider responded
+console.log(
+  `Provider used: ${result.debug.providerHistory[0].id} (${result.debug.providerHistory[0].model})`
+);
 ```
 
 ### Migration Strategies

--- a/USAGE-GUIDE.md
+++ b/USAGE-GUIDE.md
@@ -243,6 +243,7 @@ if (result.debug) {
   console.log(`📋 Execution plan:`, result.debug.plan);
   console.log(`🔄 Steps executed: ${result.debug.steps}`);
   console.log(`🔍 Reflections: ${result.debug.reflections}`);
+  console.log(`🔧 Providers used:`, result.debug.providerHistory);
 }
 ```
 

--- a/src/__tests__/conversationAgent.test.ts
+++ b/src/__tests__/conversationAgent.test.ts
@@ -124,6 +124,7 @@ test('ConversationAgent with full metrics', async () => {
   assert.ok(result.debug.plan);
   assert.equal(typeof result.debug.steps, 'number');
   assert.equal(typeof result.debug.reflections, 'number');
+  assert.ok(Array.isArray(result.debug.providerHistory));
 });
 
 test('ConversationAgent handles provider racing', async () => {

--- a/src/core/Executor.ts
+++ b/src/core/Executor.ts
@@ -167,7 +167,11 @@ export class Executor {
   /**
    * Processes provider result into standardized format
    */
-  private processProviderResult(result: ChatResult, ctx: AgentContext, providerId: string): StepResult {
+  private processProviderResult(
+    result: ChatResult,
+    ctx: AgentContext,
+    providerId: string
+  ): StepResult {
     const assistantMessage = result.messages[result.messages.length - 1];
     
     if (!assistantMessage) {
@@ -186,7 +190,11 @@ export class Executor {
     return {
       delta: [assistantMessage],
       isComplete: !hasPendingToolCalls && result.finishReason === 'stop',
-      metrics
+      metrics,
+      providerUsed: {
+        id: providerId,
+        model: ctx.providerModels?.[providerId]
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
- show provider info in debug output
- track provider history in `ConversationAgent`
- expose provider info via `StepResult` and debug docs
- update tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68569a1db22c83329bd153e03a8d9512